### PR TITLE
Song info, master control, and shuffle play

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -436,6 +436,8 @@ class SpotifySkill(CommonPlaySkill):
         if not data:
             confidence, data = self.specific_query(phrase, bonus)
             if not data:
+                phrase = re.sub(self.translate_regex('on_shuffle'), '', phrase,
+                                re.IGNORECASE)
                 confidence, data = self.generic_query(phrase, bonus)
 
         if data:
@@ -498,6 +500,15 @@ class SpotifySkill(CommonPlaySkill):
 
         Returns: Tuple with confidence and data or NOTHING_FOUND
         """
+        # Check for shuffle first
+        match = re.match(self.translate_regex('shuffle_play'), phrase,
+                         re.IGNORECASE)
+        if match:
+            self.log.info('match found for shuffle')
+            self.schedule_event(self.shuffle_on, 10, name='SpotifyShuffleOn')
+            phrase = match.groupdict()['query']
+            self.log.info('continuing with phrase {}: '.format(phrase))
+
         # Check if saved
         match = re.match(self.translate_regex('saved_songs'), phrase,
                          re.IGNORECASE)
@@ -525,6 +536,8 @@ class SpotifySkill(CommonPlaySkill):
         if match:
             artist = match.groupdict()['artist']
             return self.query_artist(artist, bonus)
+
+        # Check song
         match = re.match(self.translate_regex('song'), phrase,
                          re.IGNORECASE)
         if match:

--- a/locale/en-us/on_shuffle.regex
+++ b/locale/en-us/on_shuffle.regex
@@ -1,0 +1,1 @@
+\s*(on|with|and) shuffle\s*

--- a/locale/en-us/shuffle_play.regex
+++ b/locale/en-us/shuffle_play.regex
@@ -1,0 +1,1 @@
+(?P<query>.+) on shuffle


### PR DESCRIPTION
Three separate changes:
- Enabling "what song is this?"/"What are we listening to?" functionality
- Adding option to allow mycroft to control playback on other spotify devices, if allow_master_control is set to true in settings.json
- Adding option to turn on shuffle when starting playback, with commands like "play the beatles on shuffle", or "play the album the dark side of the moon on shuffle". Note that this currently has a limitation that shuffle only applies from the 2nd track onwards (i.e. the first track is always the same - namely the first track on the album/playlist or the 'top' track for an artist)